### PR TITLE
Add a group of snippets tool for VS Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 - [vscode-element-helper](https://github.com/ElemeFE/vscode-element-helper) An VSCode version of element-helper
 - [vue-element-ui-snippets](https://github.com/solobat/vue-element-ui-snippets) An Atom plugin providing snippets for Element
 - [Element-UI-Snippets-ST](https://github.com/snowffer/Element-UI-Snippets-ST) A group of Sublime Text code snippets for Element-UI
+- [Element-UI-Snippets-VSCode](https://github.com/snowffer/Element-UI-Snippets-VSCode) A group of VS Code code snippets for Element-UI
 - [element-ui-scaffold](https://scaffoldhub.io/vue-sample) Vue 2 with Element-UI CRUD scaffold/generator.
 - [element-ui-firebase-scaffold](https://scaffoldhub.io/vue-firebase) Vue 2, Element-UI and Firebase scaffold/generator with CRUDs, authentication, file/image upload, activity log and more.
 


### PR DESCRIPTION
The code snippets of Element UI for VS Code which is already published on VS Marketplace. The snippets include all the UI components of Element UI.